### PR TITLE
work around of the track-copy issue

### DIFF
--- a/custom/correlations/custom_correlation.cpp
+++ b/custom/correlations/custom_correlation.cpp
@@ -59,11 +59,11 @@ void custom_correlation::add_real_pair(const pair *pr)
     auto first = pr->get_first_particle();
     auto second = pr->get_second_particle();
 
-    double px1 = first->get_x(), py1 = first->get_y(), pz1 = first->get_z(), e1 = first->get_e();
-    double px2 = second->get_x(), py2 = second->get_y(), pz2 = second->get_z(), e2 = second->get_e();
+    double px1 = first->get_px(), py1 = first->get_py(), pz1 = first->get_pz(), e1 = first->get_e();
+    double px2 = second->get_px(), py2 = second->get_py(), pz2 = second->get_pz(), e2 = second->get_e();
     double mass1 = std::sqrt(e1*e1 - px1*px1 - py1*py1 - pz1*pz1);
     double mass2 = std::sqrt(e2*e2 - px2*px2 - py2*py2 - pz2*pz2);
-    
+        
     double px = (mass2 * px1 - mass1 * px2) / (mass1 + mass2);
     double py = (mass2 * py1 - mass1 * py2) / (mass1 + mass2);
     double pz = (mass2 * pz1 - mass1 * pz2) / (mass1 + mass2);
@@ -75,8 +75,8 @@ void custom_correlation::add_mixed_pair(const pair *pr)
     auto first = pr->get_first_particle();
     auto second = pr->get_second_particle();
 
-    double px1 = first->get_x(), py1 = first->get_y(), pz1 = first->get_z(), e1 = first->get_e();
-    double px2 = second->get_x(), py2 = second->get_y(), pz2 = second->get_z(), e2 = second->get_e();
+    double px1 = first->get_px(), py1 = first->get_py(), pz1 = first->get_pz(), e1 = first->get_e();
+    double px2 = second->get_px(), py2 = second->get_py(), pz2 = second->get_pz(), e2 = second->get_e();
     double mass1 = std::sqrt(e1*e1 - px1*px1 - py1*py1 - pz1*pz1);
     double mass2 = std::sqrt(e2*e2 - px2*px2 - py2*py2 - pz2*pz2);
     

--- a/custom/correlations/custom_correlation.cpp
+++ b/custom/correlations/custom_correlation.cpp
@@ -58,42 +58,30 @@ void custom_correlation::add_real_pair(const pair *pr)
 {
     auto first = pr->get_first_particle();
     auto second = pr->get_second_particle();
-    auto a1 = first->get_N() + first->get_Z();
-    auto a2 = second->get_N() + second->get_Z();
 
-    std::array<double, 4> p1 = {first->get_px(), first->get_py(), first->get_pz(), first->get_e()};
-    std::array<double, 4> p2 = {second->get_px(), second->get_py(), second->get_pz(), second->get_e()};
-    std::array<double, 4> x1 = {first->get_x(), first->get_y(), first->get_z(), first->get_t()};
-    std::array<double, 4> x2 = {second->get_x(), second->get_y(), second->get_z(), second->get_t()};
-
-    for (int idim = 0; idim < 4; idim++)
-    {
-        p1[idim] /= a1;
-        p2[idim] /= a2;
-    }
-    std::array<double, 3> prel = {p1[0] - p2[0], p1[1] - p2[1], p1[2] - p2[2]};
-    double q = std::sqrt(prel[0] * prel[0] + prel[1] * prel[1] + prel[2] * prel[2]);
-    this->numerator->Fill(q);
+    double px1 = first->get_x(), py1 = first->get_y(), pz1 = first->get_z(), e1 = first->get_e();
+    double px2 = second->get_x(), py2 = second->get_y(), pz2 = second->get_z(), e2 = second->get_e();
+    double mass1 = std::sqrt(e1*e1 - px1*px1 - py1*py1 - pz1*pz1);
+    double mass2 = std::sqrt(e2*e2 - px2*px2 - py2*py2 - pz2*pz2);
+    
+    double px = (mass2 * px1 - mass1 * px2) / (mass1 + mass2);
+    double py = (mass2 * py1 - mass1 * py2) / (mass1 + mass2);
+    double pz = (mass2 * pz1 - mass1 * pz2) / (mass1 + mass2);
+    this->numerator->Fill(std::sqrt(px * px + py * py + pz * pz));
 }
 
 void custom_correlation::add_mixed_pair(const pair *pr)
 {
     auto first = pr->get_first_particle();
     auto second = pr->get_second_particle();
-    auto a1 = first->get_N() + first->get_Z();
-    auto a2 = second->get_N() + second->get_Z();
 
-    std::array<double, 4> p1 = {first->get_px(), first->get_py(), first->get_pz(), first->get_e()};
-    std::array<double, 4> p2 = {second->get_px(), second->get_py(), second->get_pz(), second->get_e()};
-    std::array<double, 4> x1 = {first->get_x(), first->get_y(), first->get_z(), first->get_t()};
-    std::array<double, 4> x2 = {second->get_x(), second->get_y(), second->get_z(), second->get_t()};
-
-    for (int idim = 0; idim < 4; idim++)
-    {
-        p1[idim] /= a1;
-        p2[idim] /= a2;
-    }
-    std::array<double, 3> prel = {p1[0] - p2[0], p1[1] - p2[1], p1[2] - p2[2]};
-    double q = std::sqrt(prel[0] * prel[0] + prel[1] * prel[1] + prel[2] * prel[2]);
-    this->denominator->Fill(q);
+    double px1 = first->get_x(), py1 = first->get_y(), pz1 = first->get_z(), e1 = first->get_e();
+    double px2 = second->get_x(), py2 = second->get_y(), pz2 = second->get_z(), e2 = second->get_e();
+    double mass1 = std::sqrt(e1*e1 - px1*px1 - py1*py1 - pz1*pz1);
+    double mass2 = std::sqrt(e2*e2 - px2*px2 - py2*py2 - pz2*pz2);
+    
+    double px = (mass2 * px1 - mass1 * px2) / (mass1 + mass2);
+    double py = (mass2 * py1 - mass1 * py2) / (mass1 + mass2);
+    double pz = (mass2 * pz1 - mass1 * pz2) / (mass1 + mass2);
+    this->denominator->Fill(std::sqrt(px * px + py * py + pz * pz));
 }

--- a/custom/cuts/custom_pair_cut.cpp
+++ b/custom/cuts/custom_pair_cut.cpp
@@ -4,24 +4,45 @@ custom_pair_cut::custom_pair_cut()
 {
     npairs_passed = 0;
     npairs_failed = 0;
-    transverse_momentum = {0.0, DBL_MAX};
+    transverse_velocity_gate = {0.0, DBL_MAX};
+    is_consider_detector_index = true;
 }
 
 custom_pair_cut::custom_pair_cut(const custom_pair_cut &cut)
 {
     npairs_passed = cut.npairs_passed;
     npairs_failed = cut.npairs_failed;
-    transverse_momentum = cut.transverse_momentum;
+    transverse_velocity_gate = cut.transverse_velocity_gate;
+    is_consider_detector_index = cut.is_consider_detector_index;
 }
 
 bool custom_pair_cut::pass(const pair *pr)
 {   
+    // kinematic cut obtained from the particle class
     auto first = pr->get_first_particle();
     auto second = pr->get_second_particle();
-    auto px = first->get_px() + second->get_px();
-    auto py = first->get_py() + second->get_py();
-    auto kt = std::sqrt(px * px + py * py);
-    bool accepted = (kt >= transverse_momentum[0] && kt <= transverse_momentum[1]);
+    // extract information stored in the `track` level
+    auto first_track = first->get_track();
+    auto second_track = second->get_track();
+
+    auto a1 = first_track->get_neutron() + first_track->get_proton();
+    auto a2 = second_track->get_neutron() + second_track->get_proton();
+    auto vx = first->get_px() / a1 + second->get_px() / a2;
+    auto vy = first->get_py() / a1 + second->get_py() / a2;
+    auto kt = std::sqrt(vx * vx + vy * vy);
+    bool accepted = (kt >= transverse_velocity_gate[0] && kt <= transverse_velocity_gate[1]);
+
+    if (is_consider_detector_index) {
+        // throw if 
+        // 1. name is not found in the std::map
+        // 2. type is incorrect
+        auto first_detector_idx = first_track->get_property<int>("detector_index");
+        auto second_detector_idx = second_track->get_property<int>("detector_index");
+
+        // reject if pair comes from the same detector
+        accepted = accepted && (first_detector_idx != second_detector_idx);
+    }
+
     accepted ? npairs_passed++ : npairs_failed++;
     return accepted;
 }

--- a/custom/cuts/custom_pair_cut.hpp
+++ b/custom/cuts/custom_pair_cut.hpp
@@ -13,12 +13,21 @@ public:
     custom_pair_cut();
     custom_pair_cut(const custom_pair_cut & cut);
     bool pass(const pair *pr);
-    void set_transverse_momentum(const double &vmin, const double &vmax) { transverse_momentum = {vmin, vmax}; }
 
+    void set_transverse_velocity_gate(const double &vmin, const double &vmax) { this->transverse_velocity_gate = {vmin, vmax}; }
+    void set_consider_detector_index(const bool &v) { this->is_consider_detector_index = v; }
+
+    bool get_consider_detector_index() const { return this->is_consider_detector_index; }
+    std::array<double, 2> get_transverse_velocity_gate() const { return this->transverse_velocity_gate; }
+
+    long get_npairs_passed() const { return this->npairs_passed; }
+    long get_npairs_failed() const { return this->npairs_failed; }
 private:
     long npairs_passed;
     long npairs_failed;
-    std::array<double, 2> transverse_momentum;
+
+    bool is_consider_detector_index;
+    std::array<double, 2> transverse_velocity_gate;
 };
 
 #endif

--- a/custom/cuts/custom_track_cut.cpp
+++ b/custom/cuts/custom_track_cut.cpp
@@ -7,8 +7,7 @@ custom_track_cut::custom_track_cut()
 
     accepted_neutron = 0;
     accepted_proton = 0;
-    transverse_momentum = {0., DBL_MAX};
-    accepted_detector_idx = INT_MAX;
+    transverse_velocity_gate = {0., DBL_MAX};
 }
 
 custom_track_cut::custom_track_cut(const custom_track_cut &cut)
@@ -17,8 +16,7 @@ custom_track_cut::custom_track_cut(const custom_track_cut &cut)
     ntracks_failed = cut.ntracks_failed;
     accepted_neutron = cut.accepted_neutron;
     accepted_proton = cut.accepted_proton;
-    transverse_momentum = cut.transverse_momentum;
-    accepted_detector_idx = cut.accepted_detector_idx;
+    transverse_velocity_gate = cut.transverse_velocity_gate;
 }
 
 bool custom_track_cut::pass(const track *trk) {
@@ -33,9 +31,8 @@ bool custom_track_cut::pass(const custom_track *ctrk)
     bool accepted = (
         ctrk->get_neutron() == this->accepted_neutron && 
         ctrk->get_proton() == this->accepted_proton &&
-        pt >= this->transverse_momentum[0] &&
-        pt <= this->transverse_momentum[1] &&
-        ctrk->get_detector_index() == this->accepted_detector_idx &&
+        pt >= this->transverse_velocity_gate[0] &&
+        pt <= this->transverse_velocity_gate[1] &&
         ctrk->get_efficiency() > this->accepted_efficiency[0] && 
         ctrk->get_efficiency() <= this->accepted_efficiency[1]
     );

--- a/custom/cuts/custom_track_cut.hpp
+++ b/custom/cuts/custom_track_cut.hpp
@@ -21,14 +21,12 @@ public:
 
     void set_accepted_neutron(const unsigned int &N) { this->accepted_neutron = N; }
     void set_accepted_proton(const unsigned int &Z) { this->accepted_proton = Z; }
-    void set_transverse_momentum(const double &vmin, const double &vmax) { this->transverse_momentum = {vmin, vmax}; }
-    void set_accepted_detector_idx(const unsigned int &idx) { this->accepted_detector_idx = idx; }
+    void set_transverse_velocity_gate(const double &vmin, const double &vmax) { this->transverse_velocity_gate = {vmin, vmax}; }
     void set_accepted_efficiency(const double &vmin, const double &vmax) { this->accepted_efficiency = {vmin, vmax}; }
 
     unsigned int get_accepted_neutron() const { return this->accepted_neutron; }
     unsigned int get_accepted_proton() const { return this->accepted_proton; }
-    int get_accepted_detector_idx() const { return this->accepted_detector_idx; }
-    std::array<double, 2> get_transverse_momentum() const { return this->transverse_momentum; }
+    std::array<double, 2> get_transverse_velocity_gate() const { return this->transverse_velocity_gate; }
     std::array<double, 2> get_accepted_efficiency() const { return this->accepted_efficiency; }
 
     long get_ntracks_passed() const { return ntracks_passed; }
@@ -36,8 +34,7 @@ public:
 
 private:
     unsigned int accepted_neutron, accepted_proton;
-    std::array<double, 2> transverse_momentum;
-    int accepted_detector_idx;
+    std::array<double, 2> transverse_velocity_gate;
     std::array<double, 2> accepted_efficiency;
     long ntracks_passed;
     long ntracks_failed;

--- a/custom/readers/custom_reader.hpp
+++ b/custom/readers/custom_reader.hpp
@@ -5,6 +5,7 @@
 #include "TChain.h"
 #include <string>
 #include <vector>
+#include <random>
 #include <stdexcept>
 
 #include "event.hpp"
@@ -34,6 +35,10 @@ public:
     event *return_event();
 
 private:
+
+    std::random_device rd;
+    std::mt19937 gen;
+
     std::string tree_name;
     TChain *chain;
     long current_event_index;

--- a/custom/readers/custom_track.cpp
+++ b/custom/readers/custom_track.cpp
@@ -2,7 +2,6 @@
 
 custom_track::custom_track() : track()
 {
-    this->detector_index = INT_MAX;
     this->efficiency = 1.;
 }
 
@@ -10,11 +9,10 @@ custom_track::custom_track(
     const unsigned int &N, const unsigned int &Z,
     const double &vx, const double &vy, const double &vz, const double &mass,
     const double &x, const double &y, const double &z, const double &t,
-    const int &index, const double &eff
+    const double &eff
     //
     ) : track(N, Z, vx, vy, vz, mass, x, y, z, t)
 {
-    this->detector_index = index;
     this->efficiency = eff;
 }
 
@@ -23,15 +21,15 @@ custom_track::custom_track(
     const double &mass, 
     const std::array<double, 3> &v,
     const std::array<double, 4> &x,
-    const int &index, const double &eff
+    const double &eff
     //
     ) : track(N, Z, mass, v, x)
 {
-    this->detector_index = index;
     this->efficiency = eff;
 }
 
 custom_track::custom_track(const custom_track & ctrk) : track(ctrk) {
-    this->detector_index = ctrk.detector_index;
     this->efficiency = ctrk.efficiency;
 }
+
+custom_track::~custom_track() {;}

--- a/custom/readers/custom_track.hpp
+++ b/custom/readers/custom_track.hpp
@@ -11,7 +11,7 @@ public:
         const unsigned int &N, const unsigned int &Z,
         const double &vx, const double &vy, const double &vz, const double &mass,
         const double &x = 0., const double &y = 0., const double &z = 0., const double &t = 0.,
-        const int &index = 0., const double &eff = 0.
+        const double &eff = 0.
         //
     );
 
@@ -19,20 +19,16 @@ public:
         const unsigned int &N, const unsigned int &Z,
         const double &mass, const std::array<double, 3> &v,
         const std::array<double, 4> &x = {0., 0., 0., 0.},
-        const int &index = 0., const double &eff = 0.
+        const double &eff = 0.
         //
     );
 
     custom_track(const custom_track &);
-    ~custom_track() {;}
+    ~custom_track();
 
-    void set_detector_index(const int & idx) { this->detector_index = idx; }
     void set_efficiency(const double & eff) { this->efficiency = eff; }
-
-    int get_detector_index() const { return this->detector_index; }
     double get_efficiency() const { return this->efficiency; }
 private:
-    int detector_index;
     double efficiency;
 };
 

--- a/dev/track.cpp
+++ b/dev/track.cpp
@@ -40,6 +40,12 @@ track::track(const track &track)
     this->y = track.y;
     this->z = track.z;
     this->t = track.t;
+
+    for (auto &[key, val] : track.properties) {this->properties[key] = val;}
 }
 
-track::~track() {}
+track::~track()
+{
+    // if not empty, destroys the contained object.
+    for (auto &[_, val] : this->properties) {val.reset();}
+}

--- a/dev/track.hpp
+++ b/dev/track.hpp
@@ -3,17 +3,19 @@
 
 #include <array>
 #include <map>
+#include <any>
 #include <string>
 #include <vector>
+#include <iostream>
 #include <stdexcept>
 
 class track
 {
 public:
     track() { ; }
-    track(const unsigned int &N, const unsigned int &Z, const double &vx, const double &vy, const double &vz, const double &mass, const double &x=0., const double &y=0., const double &z=0., const double &t=0.);
+    track(const unsigned int &N, const unsigned int &Z, const double &vx, const double &vy, const double &vz, const double &mass, const double &x = 0., const double &y = 0., const double &z = 0., const double &t = 0.);
 
-    track(const unsigned int &N, const unsigned int &Z, const double &mass, const std::array<double, 3> &v, const std::array<double, 4> &x={0., 0., 0., 0.});
+    track(const unsigned int &N, const unsigned int &Z, const double &mass, const std::array<double, 3> &v, const std::array<double, 4> &x = {0., 0., 0., 0.});
     track(const track &);
     virtual ~track();
 
@@ -39,11 +41,32 @@ public:
     void set_z(const double &z) { this->z = z; }
     void set_t(const double &t) { this->t = t; }
 
+    template <typename T>
+    void set_property(const std::string &key, const T &value) { this->properties[key] = value; }
+
+    /**
+     * @brief Get the property object, keep the implementation in this header file to avoid linker problem. 
+    */
+    template <typename T>
+    T get_property(const std::string &key) const
+    {
+        try
+        {
+            return std::any_cast<T>(this->properties.at(key));
+        }
+        catch (const std::out_of_range &e)
+        {
+            throw std::out_of_range("track::get_property: " + key + " not found.");
+        }
+        return T();
+    }
+
 private:
     unsigned int N, Z;
     double mass;
     double vx, vy, vz;
     double x, y, z, t;
+    std::map<std::string, std::any> properties;
 };
 
 #endif

--- a/exec/main.cpp
+++ b/exec/main.cpp
@@ -20,18 +20,17 @@ int main(int argc, char *argv[])
 
     trkcut1->set_accepted_neutron(1);
     trkcut1->set_accepted_proton(1);
-    trkcut1->set_transverse_momentum(0, 1e5);
-    trkcut1->set_accepted_detector_idx(0);
+    trkcut1->set_transverse_velocity_gate(0, 1e5);
     trkcut1->set_accepted_efficiency(0, 1e5);
     
     // if identical particle, second track cut should be set as first track cut
     trkcut2->set_accepted_neutron(2);
     trkcut2->set_accepted_proton(2);
-    trkcut2->set_transverse_momentum(0, 1e5);
-    trkcut2->set_accepted_detector_idx(0);
+    trkcut2->set_transverse_velocity_gate(0, 1e5);
     trkcut2->set_accepted_efficiency(0, 1e5);
 
-    prcut->set_transverse_momentum(0, 1e5);
+    prcut->set_transverse_velocity_gate(0, 1e5);
+    prcut->set_consider_detector_index(1);
 
     anal->set_event_cut(evcut);
     anal->set_first_track_cut(trkcut1);
@@ -48,14 +47,9 @@ int main(int argc, char *argv[])
 
     while (nevents_processed < 1000000 && reader_status == 0) {
         reader_status = man->process();
+        if (nevents_processed % 10000 == 0) std::cout << nevents_processed << std::endl;
         nevents_processed++;
     }
-
-    std::cout << trkcut1->get_ntracks_passed() << std::endl;
-    std::cout << trkcut1->get_ntracks_failed() << std::endl;
-    std::cout << trkcut2->get_ntracks_passed() << std::endl;
-    std::cout << trkcut2->get_ntracks_failed() << std::endl;
-
 
     TFile *outf = new TFile("output.root", "RECREATE");
     corr->Write();


### PR DESCRIPTION
It seems the additional info in derived_track will be inevitably lost after copying to particle. Now the track class use std::any for additional info in `track`. User can still derive the track class and handled in the track_cut level. Information required by pair cut should be stored directly in `track` using std::map<std::string, std::any>.
